### PR TITLE
chore: replace jcenter with mavenCentral, upgrade gradle, remove artifactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,14 @@
-
-buildscript {
-    repositories {
-        jcenter()
-        mavenCentral()
-    }
-
-    dependencies {
-        // Artifactory plugin
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.0.0')
-    }
-}
-
 plugins {
-	id 'java'
-	id 'idea'
-	id 'net.minecrell.licenser' version '0.3'
-    id 'maven'
+    id 'java-library'
     id 'maven-publish'
 }
 
-apply plugin: 'com.jfrog.artifactory'
+ext {
+    JNLuaVersion = '1.0.0'
+}
+
+apply from: "$rootDir/gradle/common.gradle"
+
 
 repositories {
 	mavenCentral()
@@ -27,10 +16,6 @@ repositories {
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-
-license {
-    header = project.file('LICENSE.txt')
-}
 
 dependencies {
 	testCompile 'junit:junit:4.12'
@@ -55,85 +40,6 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     description = "Create a JAR with the JavaDoc for the java sources"
     from javadoc.destinationDir
     classifier = 'javadoc'
-}
-
-artifactory {
-    contextUrl = 'http://artifactory.terasology.org/artifactory'
-
-    // This is the target for publishing artifacts. Unless testing locally usually the setting in Jenkins is used
-    publish {
-        repository {
-            // The repoKey can be overridden in Jenkins and via local gradle.properties if desired for testing
-            if (rootProject.hasProperty("artifactoryPublishRepo")) {
-                repoKey = artifactoryPublishRepo
-                println "Changing PUBLISH repoKey to $artifactoryPublishRepo"
-            } else {
-                repoKey = 'terasology-snapshot-local'
-                println "PUBLISH repoKey is terasology-snapshot-local (default value)"
-            }
-
-            // User and pass are overridden in Jenkins. You can supply your own for manual use in a local prop file, such as gradle.properties
-            // This way we make it so you can run locally without having the user/pass set - but if the artifactoryPublish task is called it'll fail
-            if (rootProject.hasProperty("artifactoryUser") && rootProject.hasProperty("artifactoryPass")) {
-                username = "$artifactoryUser"
-                password = "$artifactoryPass"
-            }
-            // Note that republishing artifacts under the same name (without an incremented SNAPSHOT for instance) may fail with "Forbidden"
-        }
-
-        defaults {
-            publications ('mavenJava')
-        }
-    }
-
-    // This is the source where we get dependencies. Or it would be but it does not appear to work
-    // Only the main repositories {} seems to matter, and if commented out this still doesn't help
-    // After a Jenkins upgrade in March 2015 the setting in Jenkins started working. Needs retesting here
-    resolve {
-        repository {
-            // The repoKey can be overridden in Jenkins and via local gradle.properties if desired for testing
-            if (rootProject.hasProperty("artifactoryResolveRepo")) {
-                repoKey = artifactoryResolveRepo
-                println "Changing RESOLVE repoKey to $artifactoryResolveRepo"
-            } else {
-                repoKey = 'virtual-repo-live'
-                println "RESOLVE repoKey is virtual-repo-live (default value)"
-            }
-        }
-    }
-}
-
-// A configuration for publishing artifacts
-configurations {
-    published
-}
-
-// Define the artifacts we want to publish (the .pom will also be included since the Maven plugin is active)
-artifacts {
-    published jar
-    published sourceJar
-    published javadocJar
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            // Without this we get a .pom with no dependencies
-            from components.java
-
-            artifact jar
-            artifact sourceJar {
-                classifier "sources"
-            }
-            artifact javadocJar {
-                classifier "javadoc"
-            }
-        }
-    }
-}
-
-artifactoryPublish {
-    dependsOn jar, sourceJar, javadocJar
 }
 
 javadoc {

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -1,0 +1,114 @@
+java {
+    sourceCompatibility(JavaVersion.VERSION_1_8)
+    targetCompatibility(JavaVersion.VERSION_1_8)
+}
+
+// We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
+repositories {
+    // For development so you can publish binaries locally and have them grabbed from there
+    mavenLocal()
+
+    // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
+    mavenCentral()
+
+    // Used for gestalt 7 - Android annotations
+    google()
+
+    // Terasology Artifactory instance for libs not readily available elsewhere plus our own libs
+    maven {
+        def repoViaEnv = System.getenv()["RESOLUTION_REPO"]
+        if (rootProject.hasProperty("alternativeResolutionRepo")) {
+            // If the user supplies an alternative repo via gradle.properties then use that
+            name "from alternativeResolutionRepo property"
+            url alternativeResolutionRepo
+        } else if (repoViaEnv != null && repoViaEnv != "") {
+            name "from \$RESOLUTION_REPO"
+            url = repoViaEnv
+        } else {
+            // Our default is the main virtual repo containing everything except repos for testing Artifactory itself
+            name "Terasology Artifactory"
+            url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
+            allowInsecureProtocol true  // 😱
+        }
+    }
+
+    maven {
+        name "snowplow (pre-0.9)"
+        url "http://maven.snplow.com/releases"
+        allowInsecureProtocol true  // 😱
+    }
+}
+
+// Extra details provided for unit tests
+test {
+    useJUnitPlatform()
+
+    // ignoreFailures: Specifies whether the build should break when the verifications performed by this task fail.
+    ignoreFailures = true
+    // showStandardStreams: makes the standard streams (err and out) visible at console when running tests
+    testLogging.showStandardStreams = true
+    reports {
+        junitXml.enabled = true
+    }
+    // Arguments to include while running tests
+    jvmArgs '-Xms512m', '-Xmx1024m'
+}
+
+// In theory all Javadoc should be good and fixed, but it might be a bit much to entirely fail a build over. For now at least ...
+// Note: In IntelliJ 2020.1+ running a javadoc Gradle task may still *look* alarming in the UI, but errors should be ignored
+javadoc {
+    failOnError = false
+}
+
+group = 'org.terasology.nui'
+version = JNLuaVersion
+
+publishing {
+    publications {
+        "$project.name"(MavenPublication) {
+            // Without this we get a .pom with no dependencies
+            from components.java
+
+            repositories {
+                maven {
+                    name = 'TerasologyOrg'
+                    allowInsecureProtocol true // 😱 - no https on our Artifactory yet
+
+                    if (rootProject.hasProperty("publishRepo")) {
+                        // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
+                        url = "http://artifactory.terasology.org/artifactory/$publishRepo"
+
+                        logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
+                    } else {
+                        // Support override from the environment to use a different target publish org
+                        String deducedPublishRepo = System.getenv()["PUBLISH_ORG"]
+                        if (deducedPublishRepo == null || deducedPublishRepo == "") {
+                            // If not then default
+                            deducedPublishRepo = "libs"
+                        }
+
+                        // Base final publish repo on whether we're building a snapshot or a release
+                        if (project.version.endsWith('SNAPSHOT')) {
+                            deducedPublishRepo += "-snapshot-local"
+                        } else {
+                            deducedPublishRepo += "-release-local"
+                        }
+
+                        logger.info("The final deduced publish repo is {}", deducedPublishRepo)
+                        url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
+                    }
+
+                    if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {
+                        credentials {
+                            username = "$mavenUser"
+                            password = "$mavenPass"
+                        }
+                        authentication {
+                            basic(BasicAuthentication)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip


### PR DESCRIPTION
I used the common.gradle from TeraNUI and dropped artifactory. I think we just publish to maven directly since the artifactory is problematic to use. 

Locally building with `./gradlew build --no-build-cache --refresh-dependencies`. I don't think we need to worry since I don't see any dependencies. we need to verify if this should work on the new jenkins. :package: 